### PR TITLE
Add recursion schemes

### DIFF
--- a/recursion-schemes/base.py
+++ b/recursion-schemes/base.py
@@ -15,6 +15,9 @@ def let_op(pattern, atom, templ):
 
 
 def transfer_op(metta, fname):
+    """
+    Transfers all atoms from the specified file to the current Space.
+    """
     metta2 = MeTTa()
     metta2.cwd = metta.cwd  # inherit current working directory
     metta2.import_file(fname.get_object().value)

--- a/recursion-schemes/base.py
+++ b/recursion-schemes/base.py
@@ -218,10 +218,9 @@ def make_collapse_atom(metta):
 # `superpose` receives one atom (expression) in order to make composition
 # `(superpose (collapse ...))` possible
 def superpose_op(expr):
-    if isinstance(expr, SymbolAtom):
-        return [expr]
-    return [arg for arg in expr.get_children()]
-
+    if isinstance(expr, ExpressionAtom):
+        return [arg for arg in expr.get_children()]
+    return [expr]
 
 superposeAtom = OperationAtom('superpose', superpose_op, unwrap=False)
 

--- a/recursion-schemes/base.py
+++ b/recursion-schemes/base.py
@@ -1,0 +1,357 @@
+from hyperon import *
+import os
+
+
+def match_op(space, pattern, templ_op):
+    space = space.get_object().value
+    return space.subst(pattern, templ_op)
+
+
+def transfer_op(metta, fname):
+    metta2 = MeTTa()
+    metta2.cwd = metta.cwd  # inherit current working directory
+    metta2.import_file(fname.get_object().value)
+    for atom in metta2.space.get_atoms():
+        metta.space.add_atom(atom)
+    return []
+
+
+def newTransferOp(metta):
+    return OperationAtom(
+        'transfer!',
+        lambda file: transfer_op(metta, file),
+        unwrap=False)
+
+
+def newAllAtomsOp(metta):
+    return OperationAtom(
+        'all',
+        lambda: metta.space.get_atoms(),
+        unwrap=False)
+
+
+def let_op(pattern, atom, templ):
+    space = GroundingSpace()
+    space.add_atom(atom)
+    return space.subst(pattern, templ)
+
+
+def letrec_op(subs, body):
+    # just unsugaring `let*`` into `let` substitution by substitution
+    subs = subs.get_children()
+    if len(subs) == 0:
+        return [body]
+    next_sub = subs[0].get_children()
+    if len(subs) == 1:
+        return [E(letAtom, next_sub[0], next_sub[1], body)]
+    return [E(letAtom, next_sub[0], next_sub[1], E(letrecAtom, E(*subs[1:]), body))]
+
+
+def call_atom_op(atom, method_str, *args):
+    if not isinstance(atom, GroundedAtom):
+        raise NoReduceError()
+    obj = atom.get_object().value
+    method = getattr(obj, method_str)
+    result = method(*args)
+    if result is None:
+        return []
+    # Fixme? getting results from call_atom raises some issues but convenient.
+    # Running example is call:... &self (or another imported space)
+    # However if we need to wrap the result into GroundedAtom, we don't know
+    # its type. Also, if the method returns list, we can wrap it as whole or
+    # can interpret it as multiple results.
+    # Here, we don't wrap the list as whole, but wrap its elements even they
+    # are atoms, for get_atoms to work nicely (wrapped list is not printed
+    # nicely, while not wrapping atoms results in their further reduction)
+    # This functionality can be improved/changed based on other more
+    # important examples (e.g. dealing with DNN models) in the future,
+    # while the core functions like &self.get_atoms can be dealt with
+    # separately
+    if not isinstance(result, list):
+        result = [result]
+    result = [ValueAtom(r) for r in result]
+    # result = [r if isinstance(r, Atom) else ValueAtom(r) for r in result]
+    return result
+
+
+def print_op(atom):
+    print(atom)
+    return []
+
+
+def assertResultsEqual(result, expected):
+    report = "Expected: " + str(expected) + "\nGot: " + str(result)
+    for r in result:
+        if not r in expected:
+            raise RuntimeError(report + "\nExcessive result: " + str(r))
+    for e in expected:
+        if not e in result:
+            raise RuntimeError(report + "\nMissed result: " + str(e))
+    if len(expected) != len(result):
+        # NOTE: (1 1 2) vs (1 2 2) will pass
+        raise RuntimeError(report + "\nDifferent number of eleemnt")
+    return []
+
+
+def newAssertEqualAtom(metta):
+    return OperationAtom(
+        'assertEqual',
+        lambda e1, e2: assertResultsEqual(interpret(metta.space, e1), interpret(metta.space, e2)),
+        [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
+        unwrap=False)
+
+
+def newAssertEqualToResultAtom(metta):
+    return OperationAtom(
+        'assertEqualToResult',
+        lambda expr, expected: assertResultsEqual(interpret(metta.space, expr), expected.get_children()),
+        [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
+        unwrap=False)
+
+
+# E(S('->'), S('Number'), S('Number'), S('Number'))
+subAtom = OperationAtom('-', lambda a, b: a - b, ['Number', 'Number', 'Number'])
+mulAtom = OperationAtom('*', lambda a, b: a * b, ['Number', 'Number', 'Number'])
+addAtom = OperationAtom('+', lambda a, b: a + b, ['Number', 'Number', 'Number'])
+divAtom = OperationAtom('/', lambda a, b: a / b, ['Number', 'Number', 'Number'])
+modAtom = OperationAtom('%', lambda a, b: a % b, ['Number', 'Number', 'Number'])
+equalAtom = OperationAtom('==', lambda a, b: a == b, ['$t', '$t', 'Bool'])
+greaterAtom = OperationAtom('>', lambda a, b: a > b, ['Number', 'Number', 'Bool'])
+lessAtom = OperationAtom('<', lambda a, b: a < b, ['Number', 'Number', 'Bool'])
+orAtom = OperationAtom('or', lambda a, b: a or b, ['Bool', 'Bool', 'Bool'])
+andAtom = OperationAtom('and', lambda a, b: a and b, ['Bool', 'Bool', 'Bool'])
+notAtom = OperationAtom('not', lambda a: not a, ['Bool', 'Bool'])
+
+# Any number of arguments for `nop` (including zero) due to *args
+nopAtom = OperationAtom('nop', lambda *args: [], unwrap=False)
+
+# FIXME? Undefined for the argument is necessary to make argument reductable.
+letAtom = OperationAtom('let', let_op,
+                        type_names=[AtomType.VARIABLE, AtomType.UNDEFINED, AtomType.ATOM, AtomType.ATOM], unwrap=False)
+# The first argument is an Atom, because it has to be evaluated iteratively
+letrecAtom = OperationAtom('let*', letrec_op,
+                           type_names=[AtomType.ATOM, AtomType.ATOM, AtomType.ATOM], unwrap=False)
+matchAtom = OperationAtom('match', match_op,
+                          type_names=["Space", AtomType.ATOM, AtomType.ATOM, AtomType.UNDEFINED], unwrap=False)
+
+printAtom = OperationAtom('println!', print_op, [AtomType.UNDEFINED, 'IO'], unwrap=False)
+
+
+def newCallAtom(token):
+    # NOTE: we could use "call" as a plain symbol (insted of "call:...")
+    #       with the method name as the parameter of call_atom_op
+    #       (but this parameter should be unwrapped)
+    # "call:..." is an interesting example of families of tokens for ops, though
+    return OperationAtom(
+        token,
+        lambda obj, *args: call_atom_op(obj, token[5:], *args),
+        unwrap=False)
+
+
+def SpaceAtom(grounding_space, repr_name=None):
+    # Overriding grounding_space.repr_name here
+    # It will be changed in all occurences of this Space
+    if repr_name is not None:
+        grounding_space.repr_name = repr_name
+    return ValueAtom(grounding_space, 'Space')
+
+
+def import_op(metta, space, fname):
+    # Check if space wasn't resolved
+    if space.get_type() == AtomKind.SYMBOL:
+        # Create new space
+        name = space.get_name()
+        space = GroundingSpace()
+        # Register this space under name `name`
+        metta.add_atom(name, SpaceAtom(space, name))
+    else:
+        space = space.get_object().value
+    # A tricky part (FixMe or is this behavior indended?):
+    # * `run` will create another MeTTa object,
+    #   which will resolve `&self` as `space`, all
+    #   other syntax modification will not be inherited,
+    #   so the file should not know that it is imported,
+    #   but it will not be able to use parent's tokens
+    # * tokens introduced in the file, will be resolved
+    #   during its processing, and will be lost after it,
+    #   so we cannot import syntax this way - only spaces
+    # (another operation is needed for importing syntax)
+    metta2 = MeTTa(space)
+    metta2.cwd = metta.cwd  # inherit current working directory
+    return metta2.import_file(fname.get_object().value)
+
+
+def newImportOp(metta):
+    # unwrap=False, because space name can remain
+    # an unresolved symbol atom
+    return OperationAtom(
+        'import!',
+        lambda s, f: import_op(metta, s, f),
+        unwrap=False)
+
+
+def pragma_op(metta, key, *args):
+    # TODO: add support for Grounded values when needed
+    metta.settings[key.get_name()] = \
+        args[0].get_name() if len(args) == 1 else \
+            [arg.get_name() for arg in args]
+    return []
+
+
+def newPragmaOp(metta):
+    return OperationAtom(
+        'pragma!',
+        lambda key, *args: pragma_op(metta, key, *args),
+        unwrap=False)
+
+
+def newCollapseAtom(metta):
+    # FIXME? Calling interpreter inside the operation is not too good
+    #        Could it be done via StepResult?
+    return OperationAtom(
+        'collapse',
+        lambda atom: [E(*interpret(metta.space, atom))],
+        [AtomType.ATOM, AtomType.ATOM],
+        unwrap=False)
+
+
+# `superpose` receives one atom (expression) in order to make composition
+# `(superpose (collapse ...))` possible
+def superpose_op(expr):
+    if isinstance(expr, SymbolAtom):
+        return [expr]
+    return [arg for arg in expr.get_children()]
+
+
+superposeAtom = OperationAtom('superpose', superpose_op, unwrap=False)
+
+
+class MeTTa:
+
+    def __init__(self, space=None):
+        self.space = GroundingSpace("&self") if space is None else space
+        self.tokenizer = Tokenizer()
+        self.cwd = []  # current working directory as an array
+        self._tokenizer()
+
+    def _tokenizer(self):
+        self.add_atom(r"\+", addAtom)
+        self.add_atom(r"-", subAtom)
+        self.add_atom(r"\*", mulAtom)
+        self.add_atom(r"/", divAtom)
+        self.add_atom(r"%", modAtom)
+        self.add_atom(r"==", equalAtom)
+        self.add_atom(r"<", lessAtom)
+        self.add_atom(r">", greaterAtom)
+        self.add_atom(r"or", orAtom)
+        self.add_atom(r"and", andAtom)
+        self.add_atom(r"not", notAtom)
+        self.add_token(r"\d+(\.\d+)",
+                       lambda token: ValueAtom(float(token), 'Number'))
+        self.add_token(r"\d+",
+                       lambda token: ValueAtom(int(token), 'Number'))
+        self.add_token("\"[^\"]*\"",
+                       lambda token: ValueAtom(str(token[1:-1]), 'String'))
+        self.add_token(r"True|False",
+                       lambda token: ValueAtom(token == 'True', 'Bool'))
+        self.add_atom(r"match", matchAtom)
+        self.add_atom(r"transfer!", newTransferOp(self))
+        self.add_atom(r"all", newAllAtomsOp(self))
+        self.add_token(r"call:[^\s]+", newCallAtom)
+        self.add_atom(r"let", letAtom)
+        self.add_atom(r"let\*", letrecAtom)
+        self.add_atom(r"nop", nopAtom)
+        self.add_atom(r"assertEqual", newAssertEqualAtom(self))
+        self.add_atom(r"assertEqualToResult", newAssertEqualToResultAtom(self))
+        self.add_atom(r"println!", printAtom)
+        self.add_atom(r"&self", SpaceAtom(self.space))
+        self.add_atom(r"import!", newImportOp(self))
+        self.add_atom(r"pragma!", newPragmaOp(self))
+        self.add_atom(r"collapse", newCollapseAtom(self))
+        self.add_atom(r"superpose", superposeAtom)
+
+    def add_token(self, regexp, constr):
+        self.tokenizer.register_token(regexp, constr)
+
+    def add_atom(self, name, symbol):
+        self.add_token(name, lambda _: symbol)
+
+    def _parse_all(self, program):
+        parser = SExprParser(program)
+        while True:
+            atom = parser.parse(self.tokenizer)
+            if atom is None:
+                break
+            yield atom
+
+    def parse_all(self, program):
+        return list(self._parse_all(program))
+
+    def parse_single(self, program):
+        return next(self._parse_all(program))
+
+    def add_parse(self, program):
+        for atom in self._parse_all(program):
+            self.space.add_atom(atom)
+
+    def interpret(self, program):
+        target = self.parse_single(program)
+        return interpret(self.space, target)
+
+    def import_file(self, fname):
+        path = fname.split(os.sep)
+        f = open(os.sep.join(self.cwd + path), "r")
+        program = f.read()
+        f.close()
+        # changing cwd
+        prev_cwd = self.cwd
+        self.cwd += path[:-1]
+        result = self.run(program)
+        # restoring cwd
+        self.cwd = prev_cwd
+        return result
+
+    def run(self, program):
+        self.settings = {'type-check': None}
+        status = "normal"
+        result = []
+        for expr in self._parse_all(program):
+            if expr == S('!'):
+                status = "interp"
+                continue
+            if self.settings['type-check'] == 'auto':
+                if not validate_atom(self.space, expr):
+                    print("Type error in ", expr)
+                    break
+            if status == "interp":
+                r = interpret(self.space, expr)
+                # Empty results are also results.
+                # Can be filtered later if needed.
+                # if r != []: result += [r]
+                result += [r]
+            else:
+                self.space.add_atom(expr)
+            status = "normal"
+        return result
+
+    def lazy_import_file(self, fname):
+        path = fname.split(os.sep)
+        with open(os.sep.join(self.cwd + path), "r") as f:
+            program = f.read()
+        yield from self.lazy_run(program)
+
+    def lazy_run(self, program):
+        interpreting = False
+        commented = False
+        for expr in self._parse_all(program):
+            if expr == S('!'):
+                interpreting = True
+            elif expr == S('/*'):
+                commented = True
+            elif expr == S('*/'):
+                commented = False
+            elif interpreting and not commented:
+                yield expr, interpret(self.space, expr)
+                interpreting = False
+            elif not commented:
+                self.space.add_atom(expr)

--- a/recursion-schemes/base.py
+++ b/recursion-schemes/base.py
@@ -389,7 +389,7 @@ class MeTTa:
         interpreting = False
         commented = False
         for expr in self._parse_all(program):
-            if expr == S('!'):
+            if expr == S('!') and not commented:
                 interpreting = True
             elif expr == S('/*'):
                 commented = True

--- a/recursion-schemes/base.py
+++ b/recursion-schemes/base.py
@@ -8,6 +8,12 @@ def match_op(space, pattern, templ_op):
     return space.subst(pattern, templ_op)
 
 
+def let_op(pattern, atom, templ):
+    space = GroundingSpace()
+    space.add_atom(atom)
+    return space.subst(pattern, templ)
+
+
 def transfer_op(metta, fname):
     metta2 = MeTTa()
     metta2.cwd = metta.cwd  # inherit current working directory
@@ -29,11 +35,6 @@ def make_all_atoms_op(metta):
         lambda: metta.space.get_atoms(),
         unwrap=False)
 
-
-def let_op(pattern, atom, templ):
-    space = GroundingSpace()
-    space.add_atom(atom)
-    return space.subst(pattern, templ)
 
 
 def letrec_op(subs, body):

--- a/recursion-schemes/run.py
+++ b/recursion-schemes/run.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     t0 = monotonic_ns()
     metta = MeTTa()
     metta.cwd = ["src"]
-    for i, (expr, result_set) in enumerate(metta.lazy_import_file("examples/test.metta")):
+    for i, (expr, result_set) in enumerate(metta.lazy_import_file("examples/expression.metta")):
         if result_set:
             print(f"results of {color_expr(expr)}:")
             for result in result_set:

--- a/recursion-schemes/run.py
+++ b/recursion-schemes/run.py
@@ -1,15 +1,15 @@
 import os
 
-from base import MeTTa
+from base import MeTTa, color_expr, underline
 
 if __name__ == "__main__":
-    print("MeTTa recursion scheme example\n")
+    print(underline("MeTTa recursion scheme example\n"))
     metta = MeTTa()
     metta.cwd = ["src"]
     for i, (expr, result_set) in enumerate(metta.lazy_import_file("examples/expression.metta")):
         if result_set:
-            print(f"results of {expr}:")
+            print(f"results of {color_expr(expr)}:")
             for result in result_set:
-                print(result)
+                print(color_expr(result))
         else:
-            print(f"no result for {expr}")
+            print(f"no result for {color_expr(expr)}")

--- a/recursion-schemes/run.py
+++ b/recursion-schemes/run.py
@@ -1,0 +1,15 @@
+import os
+
+from base import MeTTa
+
+if __name__ == "__main__":
+    print("MeTTa recursion scheme example\n")
+    metta = MeTTa()
+    metta.cwd = ["src"]
+    for i, (expr, result_set) in enumerate(metta.lazy_import_file("examples/expression.metta")):
+        if result_set:
+            print(f"results of {expr}:")
+            for result in result_set:
+                print(result)
+        else:
+            print(f"no result for {expr}")

--- a/recursion-schemes/run.py
+++ b/recursion-schemes/run.py
@@ -1,15 +1,18 @@
-import os
+from time import monotonic_ns
 
 from base import MeTTa, color_expr, underline
 
+
 if __name__ == "__main__":
     print(underline("MeTTa recursion scheme example\n"))
+    t0 = monotonic_ns()
     metta = MeTTa()
     metta.cwd = ["src"]
-    for i, (expr, result_set) in enumerate(metta.lazy_import_file("examples/expression.metta")):
+    for i, (expr, result_set) in enumerate(metta.lazy_import_file("examples/test.metta")):
         if result_set:
             print(f"results of {color_expr(expr)}:")
             for result in result_set:
                 print(color_expr(result))
         else:
             print(f"no result for {color_expr(expr)}")
+    print(f"\nexecution took {(monotonic_ns() - t0)/1e9:.5} seconds")

--- a/recursion-schemes/src/base.metta
+++ b/recursion-schemes/src/base.metta
@@ -1,3 +1,6 @@
+; Wrapping and unwrapping for the recursion
+; Fix F = F (Fix F)
 (= (unFix (Fix $x)) $x)
 
+; identity function, useful in the combinators due to lack of
 (= (identity $x) $x)

--- a/recursion-schemes/src/base.metta
+++ b/recursion-schemes/src/base.metta
@@ -1,1 +1,3 @@
 (= (unFix (Fix $x)) $x)
+
+(= (identity $x) $x)

--- a/recursion-schemes/src/base.metta
+++ b/recursion-schemes/src/base.metta
@@ -1,0 +1,1 @@
+(= (unFix (Fix $x)) $x)

--- a/recursion-schemes/src/examples/benchmark.metta
+++ b/recursion-schemes/src/examples/benchmark.metta
@@ -1,4 +1,5 @@
 !(transfer! "schemes.metta")
+; A standard benchmark to test (naive) recursion scheme performance
 
 (= (mapExpr $f (Plus $x $y)) (Plus ($f $x) ($f $y)))
 (= (mapExpr $f (Const $x)) (Const $x))
@@ -20,4 +21,6 @@
 
 (= (peano $n) (if (== $n 0) Z (S (- $n 1))))
 
-!((hylo mapExpr evalExpr nTimes) (, 3 ((cata mapNat identity) ((ana mapNat peano) 10))))
+; Generates the peano number for 10, removes the Fix layers
+; Then generates the "add 3 10 times" expression, evaluates it to 30
+!((hylo mapExpr evalExpr nTimes) (, 3 ((hylo mapNat identity peano) 10)))

--- a/recursion-schemes/src/examples/benchmark.metta
+++ b/recursion-schemes/src/examples/benchmark.metta
@@ -1,0 +1,23 @@
+!(transfer! "schemes.metta")
+
+(= (mapExpr $f (Plus $x $y)) (Plus ($f $x) ($f $y)))
+(= (mapExpr $f (Const $x)) (Const $x))
+(= (mapExpr $f (Var $x)) (Var $x))
+
+(= (mapNat $f (S $n)) (S ($f $n)))
+(= (mapNat $f Z) Z)
+
+(= (evalExpr (Plus $x $y)) (+ $x $y))
+(= (evalExpr (Const $x)) $x)
+(= (evalExpr (Var $x)) (valueOf $x))
+
+(= (nTimes (, $x (S (S $n)))) (Plus (, $x (S Z)) (, $x (S $n))))
+(= (nTimes (, $x (S Z))) (Const $x))
+(= (nTimes (, $_ Z)) (Const 0))
+
+(= (if True $x $y) $x)
+(= (if False $x $y) $y)
+
+(= (peano $n) (if (== $n 0) Z (S (- $n 1))))
+
+!((hylo mapExpr evalExpr nTimes) (, 3 ((cata mapNat identity) ((ana mapNat peano) 10))))

--- a/recursion-schemes/src/examples/expression.metta
+++ b/recursion-schemes/src/examples/expression.metta
@@ -1,33 +1,45 @@
 !(transfer! "schemes.metta")
 
+; How to apply a function to the slots, a Functor's map
 (= (mapExpr $f (Plus $x $y)) (Plus ($f $x) ($f $y)))
 (= (mapExpr $f (Const $x)) (Const $x))
 (= (mapExpr $f (Var $x)) (Var $x))
 
+; How to evaluate the structure to some value, a single step, an algebra
 (= (evalExpr (Plus $x $y)) (+ $x $y))
 (= (evalExpr (Const $x)) $x)
 (= (evalExpr (Var $x)) (valueOf $x))
 
+; Dictionary we can use during evaluation
 (= (valueOf X) 0)
+; A fold, with the Functor and algebra, applied to the Fix tree
 !((cata mapExpr evalExpr) (Fix (Plus (Fix (Plus (Fix (Var X)) (Fix (Const 2)))) (Fix (Const 40)))))
 
+; How to generate the structure based on some value, a single step, a co-algebra
 (= (nTimes (, $x (S (S $n)))) (Plus (, $x (S Z)) (, $x (S $n))))
 (= (nTimes (, $x (S Z))) (Const $x))
 (= (nTimes (, $_ Z)) (Const 0))
 
+; An unfold, with the Functor and co-algebra, applied to some seed value
 !((ana mapExpr nTimes) (, 2 (S (S Z))))
 
+; Combining both into a "re-fold", starting with a (co-algebra) seed value, ending with a (algebra) result value
 !((hylo mapExpr evalExpr nTimes) (, 3 (S (S (S Z)))))
 
-(= (diff (Const $_)) (Const 0))
-(= (diff (Var $_)) (Const 1))
-(= (diff (Plus (, $x $_1) (, $y $_2))) (Plus $x $y))
+; How to evaluate the structure, with access to the original expression (on top of the processed value)
+(= (diff (Const $_)) (Fix (Const 0)))
+(= (diff (Var $_)) (Fix (Const 1)))
+(= (diff (Plus (, $dx $x) (, $dy $y))) (Fix (Plus $dx $dy)))
+; (= (diff (Times (, $dx $x) (, $dy $y))) (Fix (Plus (Fix (Times $dx $y)) (Fix (Times $dy $x)))))
 
 !((para mapExpr diff) (Fix (Plus (Fix (Var X)) (Fix (Const 1)))))
 
+; Unfold shorthand definitions like "1p" for "1 + X" into a Bind-Pure tree of expressions
 (= (expand (1p $x)) (Plus (Bind (Const 1)) (Pure $x)))
 (= (expand (2t $x)) (Plus (Pure $x) (Pure $x)))
 (= (expand (Fix $x)) $x)
 
+; Everything this can process
 !(match &self (= (expand $X) $Y) $X)
+; Expand the definition
 !((futu mapExpr expand) (2t (1p (Fix (Var X)))))

--- a/recursion-schemes/src/examples/expression.metta
+++ b/recursion-schemes/src/examples/expression.metta
@@ -7,3 +7,9 @@
 (= (evalExpr (Const $x)) $x)
 
 !((cata mapExpr evalExpr) (Fix (Plus (Fix (Plus (Fix (Const 1)) (Fix (Const 2)))) (Fix (Const 3)))))
+
+(= (nTimes (, $x (S (S $n)))) (Plus (, $x (S Z)) (, $x (S $n))))
+(= (nTimes (, $x (S Z))) (Const $x))
+(= (nTimes (, $_ Z)) (Const 0))
+
+!((ana mapExpr nTimes) (, 3 (S (S Z))))

--- a/recursion-schemes/src/examples/expression.metta
+++ b/recursion-schemes/src/examples/expression.metta
@@ -1,0 +1,9 @@
+!(transfer! "schemes.metta")
+
+(= (mapExpr $f (Plus $x $y)) (Plus ($f $x) ($f $y)))
+(= (mapExpr $f (Const $x)) (Const $x))
+
+(= (evalExpr (Plus $x $y)) ($x + $y))
+(= (evalExpr (Const $x)) $x)
+
+!((cata mapExpr evalExpr) (Fix (Plus (Fix (Plus (Fix (Const 1)) (Fix (Const 2)))) (Fix (Const 3)))))

--- a/recursion-schemes/src/examples/expression.metta
+++ b/recursion-schemes/src/examples/expression.metta
@@ -24,3 +24,9 @@
 (= (diff (Plus (, $x $_1) (, $y $_2))) (Plus $x $y))
 
 !((para mapExpr diff) (Fix (Plus (Fix (Var X)) (Fix (Const 1)))))
+
+(= (expand (1p $x)) (Plus (Bind (Const 1)) (Pure $x)))
+(= (expand (2t $x)) (Plus (Pure $x) (Pure $x)))
+(= (expand (Fix $x)) $x)
+
+!((futu mapExpr expand) (2t (1p (Fix (Var X)))))

--- a/recursion-schemes/src/examples/expression.metta
+++ b/recursion-schemes/src/examples/expression.metta
@@ -12,4 +12,6 @@
 (= (nTimes (, $x (S Z))) (Const $x))
 (= (nTimes (, $_ Z)) (Const 0))
 
-!((ana mapExpr nTimes) (, 3 (S (S Z))))
+!((ana mapExpr nTimes) (, 2 (S (S Z))))
+
+!((hylo mapExpr evalExpr nTimes) (, 3 (S (S (S Z)))))

--- a/recursion-schemes/src/examples/expression.metta
+++ b/recursion-schemes/src/examples/expression.metta
@@ -29,4 +29,5 @@
 (= (expand (2t $x)) (Plus (Pure $x) (Pure $x)))
 (= (expand (Fix $x)) $x)
 
+!(match &self (= (expand $X) $Y) $X)
 !((futu mapExpr expand) (2t (1p (Fix (Var X)))))

--- a/recursion-schemes/src/examples/expression.metta
+++ b/recursion-schemes/src/examples/expression.metta
@@ -2,11 +2,14 @@
 
 (= (mapExpr $f (Plus $x $y)) (Plus ($f $x) ($f $y)))
 (= (mapExpr $f (Const $x)) (Const $x))
+(= (mapExpr $f (Var $x)) (Var $x))
 
-(= (evalExpr (Plus $x $y)) ($x + $y))
+(= (evalExpr (Plus $x $y)) (+ $x $y))
 (= (evalExpr (Const $x)) $x)
+(= (evalExpr (Var $x)) (valueOf $x))
 
-!((cata mapExpr evalExpr) (Fix (Plus (Fix (Plus (Fix (Const 1)) (Fix (Const 2)))) (Fix (Const 3)))))
+(= (valueOf X) 0)
+!((cata mapExpr evalExpr) (Fix (Plus (Fix (Plus (Fix (Var X)) (Fix (Const 2)))) (Fix (Const 40)))))
 
 (= (nTimes (, $x (S (S $n)))) (Plus (, $x (S Z)) (, $x (S $n))))
 (= (nTimes (, $x (S Z))) (Const $x))
@@ -15,3 +18,9 @@
 !((ana mapExpr nTimes) (, 2 (S (S Z))))
 
 !((hylo mapExpr evalExpr nTimes) (, 3 (S (S (S Z)))))
+
+(= (diff (Const $_)) (Const 0))
+(= (diff (Var $_)) (Const 1))
+(= (diff (Plus (, $x $_1) (, $y $_2))) (Plus $x $y))
+
+!((para mapExpr diff) (Fix (Plus (Fix (Var X)) (Fix (Const 1)))))

--- a/recursion-schemes/src/schemes.metta
+++ b/recursion-schemes/src/schemes.metta
@@ -3,3 +3,5 @@
 (= ((cata $F $alg) $a) ($alg ($F (cata $F $alg) (unFix $a))))
 
 (= ((ana $F $coalg) $s) (fix ($F (ana $F $coalg) ($coalg $s))))
+
+(= ((hylo $F $alg $coalg) $s) ($alg ($F (hylo $F $alg $coalg) ($coalg $s))))

--- a/recursion-schemes/src/schemes.metta
+++ b/recursion-schemes/src/schemes.metta
@@ -1,3 +1,5 @@
 !(transfer! "base.metta")
 
 (= ((cata $F $alg) $a) ($alg ($F (cata $F $alg) (unFix $a))))
+
+(= ((ana $F $coalg) $s) (fix ($F (ana $F $coalg) ($coalg $s))))

--- a/recursion-schemes/src/schemes.metta
+++ b/recursion-schemes/src/schemes.metta
@@ -1,3 +1,5 @@
+; For references see https://github.com/passy/awesome-recursion-schemes
+; For my typed Scala implementation see https://github.com/Adam-Vandervorst/RecursionSchemes
 !(transfer! "base.metta")
 
 ; folds

--- a/recursion-schemes/src/schemes.metta
+++ b/recursion-schemes/src/schemes.metta
@@ -1,0 +1,3 @@
+!(transfer! "base.metta")
+
+(= ((cata $F $alg) $a) ($alg ($F (cata $F $alg) (unFix $a))))

--- a/recursion-schemes/src/schemes.metta
+++ b/recursion-schemes/src/schemes.metta
@@ -1,10 +1,17 @@
 !(transfer! "base.metta")
 
+; folds
 (= ((cata $F $alg) $a) ($alg ($F (cata $F $alg) (unFix $a))))
 
 (= ((para_pair $F $alg) $a) (, ((para $F $alg) $a) $a))
 (= ((para $F $alg) $a) ($alg ($F (para_pair $F $alg) (unFix $a))))
 
+; unfolds
 (= ((ana $F $coalg) $s) (Fix ($F (ana $F $coalg) ($coalg $s))))
 
+(= ((futu_picking $F $coalg) (Pure $a)) ((futu $F $coalg) $a))
+(= ((futu_picking $F $coalg) (Bind $f)) (Fix ($F (futu_picking $F $coalg) $f)))
+(= ((futu $F $coalg) $s) (Fix ($F (futu_picking $F $coalg) ($coalg $s))))
+
+; combinations
 (= ((hylo $F $alg $coalg) $s) ($alg ($F (hylo $F $alg $coalg) ($coalg $s))))

--- a/recursion-schemes/src/schemes.metta
+++ b/recursion-schemes/src/schemes.metta
@@ -2,6 +2,9 @@
 
 (= ((cata $F $alg) $a) ($alg ($F (cata $F $alg) (unFix $a))))
 
-(= ((ana $F $coalg) $s) (fix ($F (ana $F $coalg) ($coalg $s))))
+(= ((para_pair $F $alg) $a) (, ((para $F $alg) $a) $a))
+(= ((para $F $alg) $a) ($alg ($F (para_pair $F $alg) (unFix $a))))
+
+(= ((ana $F $coalg) $s) (Fix ($F (ana $F $coalg) ($coalg $s))))
 
 (= ((hylo $F $alg $coalg) $s) ($alg ($F (hylo $F $alg $coalg) ($coalg $s))))


### PR DESCRIPTION
On top of the recursion schemes implementation, examples, and benchmark,
it adds lazy evaluation, block-comments, an import-all statement, timing, and some syntax highlighting,
which we may want to integrate into hyperon-experimental.

Notably a README is missing. There should probably be a standard one at the root of the project explaining how to run examples, with an additional one here explaining what recursion schemes are and how not be afraid of them.