### PR TITLE
SICP example review notes

### DIFF
--- a/SICP_book/chapter_1_1.metta
+++ b/SICP_book/chapter_1_1.metta
@@ -101,7 +101,7 @@
     $y))
 
 ; In the case of metta, evaluation type depends on the type definition of function "test".
-; Default type which is %undefined% implies applicative-order,
+; Default type which is %Undefined% implies applicative-order,
 ; while (: test (-> Number Atom Atom)) implies normal-order evaluation.
 !(test 0 (p))
 

--- a/SICP_book/chapter_1_3.metta
+++ b/SICP_book/chapter_1_3.metta
@@ -1,4 +1,18 @@
-;needed for putting lambda functions as input to functions
+; Note: The following lambdaX type definition is more correct:
+; (: lambdaX (-> Variable Variable ... $t (-> $a $b ... $t)))
+; This definition also makes some additional examples work (see below).
+; But it doesn't prevent interpreter from evaluation of lambda's body
+; before lambda call is actually made. This is why Atom type
+; is used instead for the $body argument.
+
+; Note: The only reason why different definitions of lambdaX are needed is
+; that we would like to make lambda's interchangeable with other functions.
+; Otherwise we could define universal lambda like this:
+; (= ((lambda ; $vars $body) $vals) (let $vars $vals $body))
+; and use it like this:
+; (let $sum (lambda ($a $b $c) (+ (+ $a $b) $c)) ($sum (1 2 3))
+
+; Needed for putting lambda functions as input to functions
 (: lambda1 (-> Variable Atom (-> $a $t)))
 (= ((lambda1 $var $body) $val)
     (let $var $val $body) )
@@ -8,25 +22,15 @@
 (= ((lambda0 $body)) $body)
 
 ; For lambda with two inputs
-; Note: The following lambda2 type definition is more correct:
-; (: lambda2 (-> Variable Variable $t (-> $a $b $t)))
-; This definition also makes some additional examples work (see below).
-; But it doesn't prevent interpreter from evaluation of lambda's body
-; before lambda call is actually made. This is why type
-; (-> Variable Variable Atom (-> $a $b $t)) is used instead.
-
 (: lambda2 (-> Variable Variable Atom (-> $a $b $t)))
 (= ((lambda2 $var1 $var2 $body) $val1 $val2)
     (let ($var1 $var2) ($val1 $val2) $body))
 
 ; For lambda with three inputs. But actually we will use it to bypass recursive limitation while
-;defining function using let
+; defining function using let
 (: lambda3 (-> Variable Variable Variable Atom (-> $a $b $c $t)))
 (= ((lambda3 $var1 $var2 $var3 $body) $val1 $val2 $val3)
     (let ($var1 $var2 $var3) ($val1 $val2 $val3) $body))
-
-; The only reason why different definitions of lambdaX are needed is that we would like to make
-; lambda's interchangeable with other functions.
 
 ; Sum from $a to $b with pre-defined transition from $a to $(a+1) $next and function $term applied to $a
 (= (sum $term $a $next $b)
@@ -379,7 +383,7 @@
                     ($self-try $next $self-try)))))
     ($try $first-guess $try)))
 
-; Requires correct lambda type to work (see note to the lambda2 definition above)
+; FIXME: Requires correct lambda type to work (see note to the lambda2 definition above)
 ;!(assertEqual
 ;    (fixed-point sqr 0.5)
 ;    0.00390625)
@@ -394,7 +398,7 @@
 ; Show that the golden ratio Phi (section 1.2.2) is a fixed point of the
 ; transformation x ->  1 + 1/x, and use this fact to compute by means of the fixed-point procedure.
 
-; Requires correct lambda type to work (see note to the lambda2 definition above)
+; FIXME: Requires correct lambda type to work (see note to the lambda2 definition above)
 ;!(assertEqual
 ;    (fixed-point (lambda1 $x (+ 1 (/ 1 $x))) 1.0)
 ;    1.6)

--- a/SICP_book/chapter_1_3.metta
+++ b/SICP_book/chapter_1_3.metta
@@ -12,10 +12,16 @@
 ; and use it like this:
 ; (let $sum (lambda ($a $b $c) (+ (+ $a $b) $c)) ($sum (1 2 3))
 
+; quoted prevents wrapped atom from being interpreted
+(: quoted (-> Atom Atom))
+
+; Note: quoted is used in lambda implementations below to prevent $body to be
+; evaluated inside let.
+
 ; Needed for putting lambda functions as input to functions
 (: lambda1 (-> Variable Atom (-> $a $t)))
 (= ((lambda1 $var $body) $val)
-    (let $var $val $body) )
+    (let (quoted $var) (quoted $val) $body) )
 
 ; For lambda without any input
 (: lambda0 (-> Atom (-> $t)))
@@ -24,13 +30,13 @@
 ; For lambda with two inputs
 (: lambda2 (-> Variable Variable Atom (-> $a $b $t)))
 (= ((lambda2 $var1 $var2 $body) $val1 $val2)
-    (let ($var1 $var2) ($val1 $val2) $body))
+    (let (quoted ($var1 $var2)) (quoted ($val1 $val2)) $body))
 
 ; For lambda with three inputs. But actually we will use it to bypass recursive limitation while
 ; defining function using let
 (: lambda3 (-> Variable Variable Variable Atom (-> $a $b $c $t)))
 (= ((lambda3 $var1 $var2 $var3 $body) $val1 $val2 $val3)
-    (let ($var1 $var2 $var3) ($val1 $val2 $val3) $body))
+    (let (quoted ($var1 $var2 $var3)) (quoted ($val1 $val2 $val3)) $body))
 
 ; Sum from $a to $b with pre-defined transition from $a to $(a+1) $next and function $term applied to $a
 (= (sum $term $a $next $b)


### PR DESCRIPTION
Comments are formatted. `quoted` is used to prevent `$body` execution inside `let` (see https://github.com/vsbogd/metta-examples/blob/f3cbdd4f4d4de79681b88452e5011e590b16e3e1/combinator_logic_experiments/y_comb_examples.metta#L61-L69). `%Undefined%` typo is fixed.