### PR TITLE
Fixes to sicp

### DIFF
--- a/SICP_book/chapter_1_1.metta
+++ b/SICP_book/chapter_1_1.metta
@@ -103,7 +103,9 @@
 ; In the case of metta, evaluation type depends on the type definition of function "test".
 ; Default type which is %Undefined% implies applicative-order,
 ; while (: test (-> Number Atom Atom)) implies normal-order evaluation.
-!(test 0 (p))
+!(assertEqual
+    (test 0 (p))
+    0)
 
 (= (average $x $y)
     (/ (+ $x $y) 2))

--- a/SICP_book/chapter_1_2.metta
+++ b/SICP_book/chapter_1_2.metta
@@ -7,8 +7,8 @@
 (= (sqr $x) (* $x $x))
 
 ; Since +,/,*,- in metta takes only two arguments as input:
-(= (+3 $a $b $c) (+ $a (+ $b $c)))
-(= (*3 $a $b $c) (* $a (* $b $c)))
+(= (p3 $a $b $c) (+ $a (+ $b $c)))
+(= (m3 $a $b $c) (* $a (* $b $c)))
 
 ; Recursive factorial evaluation
 (= (factorial $n)
@@ -93,7 +93,7 @@
 (= (exercise_1_11r $n)
     (if (< $n 3)
         $n
-        (+3 (exercise_1_11r (dec $n))
+        (p3 (exercise_1_11r (dec $n))
             (exercise_1_11r (- $n 2))
             (exercise_1_11r (- $n 3)))))
 
@@ -298,9 +298,9 @@
             (lfib-iter  $a
                         $b
                         (+ (sqr $p) (sqr $q))
-                        (+ (sqr $q) (*3 2 $p $q))
+                        (+ (sqr $q) (m3 2 $p $q))
                         (/ $count 2))
-            (lfib-iter  (+3 (* $b $q) (* $a $q) (* $a $p))
+            (lfib-iter  (p3 (* $b $q) (* $a $q) (* $a $p))
                         (+ (* $b $p) (* $a $q))
                         $p
                         $q
@@ -569,8 +569,10 @@
 ; test with a procedure analogous to fermat-test. Check your procedure by testing various known primes and non-primes.
 ; Hint: One convenient way to make expmod signal is to have it return 0.
 
+(= (and3 $a $b $c) (and $a (and $b $b)))
+
 (= (remainder-with-check $cur $m)
-    (if (and (not (== $cur 1))
+    (if (and3 (not (== $cur 1))
              (not (== $cur (dec $m)))
              (== (remainder $cur $m) 1))
         0

--- a/SICP_book/chapter_1_3.metta
+++ b/SICP_book/chapter_1_3.metta
@@ -12,16 +12,14 @@
 ; and use it like this:
 ; (let $sum (lambda ($a $b $c) (+ (+ $a $b) $c)) ($sum (1 2 3))
 
-; quoted prevents wrapped atom from being interpreted
-(: quoted (-> Atom Atom))
-
-; Note: quoted is used in lambda implementations below to prevent $body to be
+; Note: quote is used in lambda implementations below to prevent $body to be
 ; evaluated inside let.
 
 ; Needed for putting lambda functions as input to functions
 (: lambda1 (-> Variable Atom (-> $a $t)))
 (= ((lambda1 $var $body) $val)
-    (let (quoted $var) (quoted $val) $body) )
+    (let (quote ($v $b)) (sealed ($var) (quote ($var $body))) (let (quote $v) (quote $val) $b)) )
+
 
 ; For lambda without any input
 (: lambda0 (-> Atom (-> $t)))
@@ -30,13 +28,13 @@
 ; For lambda with two inputs
 (: lambda2 (-> Variable Variable Atom (-> $a $b $t)))
 (= ((lambda2 $var1 $var2 $body) $val1 $val2)
-    (let (quoted ($var1 $var2)) (quoted ($val1 $val2)) $body))
+    (let (quote ($v1 $v2 $b)) (sealed ($var1 $var2) (quote ($var1 $var2 $body))) (let (quote ($v1 $v2)) (quote ($val1 $val2)) $b)) )
 
 ; For lambda with three inputs. But actually we will use it to bypass recursive limitation while
 ; defining function using let
 (: lambda3 (-> Variable Variable Variable Atom (-> $a $b $c $t)))
 (= ((lambda3 $var1 $var2 $var3 $body) $val1 $val2 $val3)
-    (let (quoted ($var1 $var2 $var3)) (quoted ($val1 $val2 $val3)) $body))
+    (let (quote ($v1 $v2 $v3 $b)) (sealed ($var1 $var2 $var3) (quote ($var1 $var2 $var3 $body))) (let (quote ($v1 $v2 $v3)) (quote ($val1 $val2 $val3)) $b)) )
 
 ; Sum from $a to $b with pre-defined transition from $a to $(a+1) $next and function $term applied to $a
 (= (sum $term $a $next $b)
@@ -101,13 +99,13 @@
 (= (inc2 $x) (+ $x 2))
 
 ; Since metta currently doesn't support '+', '*' etc with 3+ parameters:
-(= (+4 $a $b $c $d) (+ (+ $a $b) (+ $c $d)))
-(= (+3 $a $b $c) (+ (+ $a $b) $c))
+(= (p4 $a $b $c $d) (+ (+ $a $b) (+ $c $d)))
+(= (p3 $a $b $c) (+ (+ $a $b) $c))
 
 (= (integral-simpson $f $a $b $n)
     (let $func-h (lambda0 (/ (- $b $a) $n))
         (let $element-y (lambda1 $x ($f (+ $a (* $x ($func-h)))))
-            (/ (* ($func-h) (+4 ($element-y 0) ($element-y $n)
+            (/ (* ($func-h) (p4 ($element-y 0) ($element-y $n)
                                                 (* 4 (sum $element-y 1 inc2 (dec $n)))
                                                 (* 2 (sum $element-y 2 inc2 (dec $n))))) 3))))
 
@@ -602,7 +600,7 @@
 
 (= (smooth $f)
   (lambda1 $y
-    (/ (+3 ($f $y) ($f (- $y (dx))) ($f (+ $y (dx)))) 3)))
+    (/ (p3 ($f $y) ($f (- $y (dx))) ($f (+ $y (dx)))) 3)))
 
 !(assertEqual
     ((smooth sqr) 5)

--- a/SICP_book/chapter_1_3_2.metta
+++ b/SICP_book/chapter_1_3_2.metta
@@ -7,17 +7,17 @@
 
 (: lambda1 (-> Variable Atom (-> $a $t)))
 (= ((lambda1 $var $body) $val)
-    (let (quoted $var) (quoted $val) $body) )
+    (let (quote ($v $b)) (sealed ($var) (quote ($var $body))) (let (quote $v) (quote $val) $b)) )
 
 ; For lambda with two inputs
 (= ((lambda2 $var1 $var2 $body) $val1 $val2)
-    (let (quoted ($var1 $var2)) (quoted ($val1 $val2)) $body))
+    (let (quote ($v1 $v2 $b)) (sealed ($var1 $var2) (quote ($var1 $var2 $body))) (let (quote ($v1 $v2)) (quote ($val1 $val2)) $b)) )
 
 ; For lambda with three inputs. But actually we will use it to bypass recursive limitation while
 ; defining function using let
 (: lambda3 (-> Variable Variable Variable Atom (-> $a $b $c $t)))
 (= ((lambda3 $var1 $var2 $var3 $body) $val1 $val2 $val3)
-    (let (quoted ($var1 $var2 $var3)) (quoted ($val1 $val2 $val3)) $body))
+    (let (quote ($v1 $v2 $v3 $b)) (sealed ($var1 $var2 $var3) (quote ($var1 $var2 $var3 $body))) (let (quote ($v1 $v2 $v3)) (quote ($val1 $val2 $val3)) $b)) )
 
 (= (sqr $x) (* $x $x))
 
@@ -29,8 +29,7 @@
 (= (dec $x) (- $x 1))
 
 ; Since metta currently doesn't support '+', '*' etc with 3+ parameters:
-(= (+4 $a $b $c $d) (+ (+ $a $b) (+ $c $d)))
-(= (+3 $a $b $c) (+ (+ $a $b) $c))
+(= (p4 $a $b $c $d) (+ (+ $a $b) (+ $c $d)))
 
 (= (remainder $x $y) (% $x $y))
 
@@ -179,7 +178,7 @@
 ; --------------------------------------------------------
 
 (= (cubic $a $b $c)
-  (lambda1 $x (+4 (cube $x) (* $a (sqr $x)) (* $b $x) $c)))
+  (lambda1 $x (p4 (cube $x) (* $a (sqr $x)) (* $b $x) $c)))
 
 !(assertEqual
     (newtons-method (cubic 1 2 3) 1)

--- a/SICP_book/chapter_2_1.metta
+++ b/SICP_book/chapter_2_1.metta
@@ -307,7 +307,7 @@
 
 (: lambda1 (-> Variable Atom (-> $a $t)))
 (= ((lambda1 $var $body) $val)
-    (let (quote $var) (quote $val) $body))
+    (let (quote ($v $b)) (sealed ($var) (quote ($var $body))) (let (quote $v) (quote $val) $b)) )
 
 (= (cons $x $y)
   (let $dispatch (lambda1 $m
@@ -344,7 +344,7 @@
 
 (: lambda2 (-> Variable Variable Atom (-> $a $b $t)))
 (= ((lambda2 $var1 $var2 $body) $val1 $val2)
-    (let (quote ($var1 $var2)) (quote ($val1 $val2)) $body))
+    (let (quote ($v1 $v2 $b)) (sealed ($var1 $var2) (quote ($var1 $var2 $body))) (let (quote ($v1 $v2)) (quote ($val1 $val2)) $b)) )
 
 (= (cons2 $x $y)
   (lambda1 $m ($m $x $y)))
@@ -395,7 +395,7 @@
 
 (: lambda3 (-> Variable Variable Variable Atom (-> $a $b $c $t)))
 (= ((lambda3 $var1 $var2 $var3 $body) $val1 $val2 $val3)
-    (let (quote ($var1 $var2 $var3)) (quote ($val1 $val2 $val3)) $body))
+    (let (quote ($v1 $v2 $v3 $b)) (sealed ($var1 $var2 $var3) (quote ($var1 $var2 $var3 $body))) (let (quote ($v1 $v2 $v3)) (quote ($val1 $val2 $val3)) $b)) )
 
 (= (inc $x) (+ $x 1))
 

--- a/SICP_book/chapter_2_2.metta
+++ b/SICP_book/chapter_2_2.metta
@@ -281,7 +281,7 @@
 
 (: lambda1 (-> Variable Atom (-> $a $t)))
 (= ((lambda1 $var $body) $val)
-    (let (quote $var) (quote $val) $body) )
+    (let (quote ($v $b)) (sealed ($var) (quote ($var $body))) (let (quote $v) (quote $val) $b)) )
 
 (= (square $x)
     (* $x $x))
@@ -571,12 +571,21 @@
     (tree (10 (20 (30 40) 50) (60 70))))
 
 ; Scale tree but using map for definition
+; TODO: this version of scale-tree-m more preferable but it is not working in current metta's state.
+;(= (scale-tree-m $tree $factor)
+;    (map (lambda1 $sub-tree
+;        (case $sub-tree
+;            (((Cons $x $xs) (scale-tree-m $sub-tree $factor))
+;            ($_ (* $sub-tree $factor)))))
+;            $tree))
+
+; This is the stub-version of scale-tree-m. I don't think it is quite right to do so. But let it be till problem with normal version persists.
 (= (scale-tree-m $tree $factor)
     (map (lambda1 $sub-tree
-        (case $sub-tree
-            (((Cons $x $xs) (scale-tree-m $sub-tree $factor))
-            ($_ (* $sub-tree $factor)))))
-            $tree))
+        (if (== (get-metatype $sub-tree) Expression)
+            (scale-tree-m $sub-tree $factor)
+            (* $sub-tree $factor))) $tree))
+
 !(assertEqual
     (scale-tree-m (list (1 (list (2 (list (3 4)) 5)) (list (6 7)))) 10)
     (tree (10 (20 (30 40) 50) (60 70))))
@@ -608,13 +617,19 @@
     (tree (1 (4 (9 16) 25) (36 49))))
 
 ;Using map function
+; Same problem as with scale-tree-m. Something with using case inside lambda body which then used as an input to function map.
+;(= (square-tree-m $tree)
+;    (map (lambda1 $sub-tree
+;        (case $sub-tree
+;            (((Cons $x $xs) (square-tree-m $sub-tree))
+;            ($_ (* $sub-tree $sub-tree)))))
+;            $tree))
 
 (= (square-tree-m $tree)
     (map (lambda1 $sub-tree
-        (case $sub-tree
-            (((Cons $x $xs) (square-tree-m $sub-tree))
-            ($_ (* $sub-tree $sub-tree)))))
-            $tree))
+        (if (== (get-metatype $sub-tree) Expression)
+            (square-tree-m $sub-tree)
+            (* $sub-tree $sub-tree))) $tree))
 
 !(assertEqual
     (square-tree-m (list (1 (list (2 (list (3 4)) 5)) (list (6 7)))))
@@ -791,7 +806,7 @@
 
 (: lambda2 (-> Variable Variable Atom (-> $a $b $t)))
 (= ((lambda2 $var1 $var2 $body) $val1 $val2)
-    (let (quote ($var1 $var2)) (quote ($val1 $val2)) $body))
+    (let (quote ($v1 $v2 $b)) (sealed ($var1 $var2) (quote ($var1 $var2 $body))) (let (quote ($v1 $v2)) (quote ($val1 $val2)) $b)) )
 
 (= (acc-map $p $sequence)
   (accumulate (lambda2 $x $y (Cons ($p $x) $y)) Nil $sequence))
@@ -883,9 +898,6 @@
       Nil
       (Cons (accumulate $op $init (map (lambda1 $x (car-list $x)) $seqs))
             (accumulate-n $op $init (map (lambda1 $x (cdr-list $x)) $seqs)))))
-
-
-; This one takes long time to complete
 
 !(assertEqual
     (accumulate-n + 0 (tree ((1 2 3) (4 5 6) (7 8 9) (10 11 12))))
@@ -983,7 +995,7 @@
 
 (: lambda3 (-> Variable Variable Variable Atom (-> $a $b $c $t)))
 (= ((lambda3 $var1 $var2 $var3 $body) $val1 $val2 $val3)
-    (let (quote ($var1 $var2 $var3)) (quote ($val1 $val2 $val3)) $body))
+    (let (quote ($v1 $v2 $v3 $b)) (sealed ($var1 $var2 $var3) (quote ($var1 $var2 $var3 $body))) (let (quote ($v1 $v2 $v3)) (quote ($val1 $val2 $val3)) $b)) )
 
 (= (fold-left $op $initial $sequence)
   (let $iter (lambda3 $result $rest $self
@@ -1248,24 +1260,9 @@
           ($self (- $k 1) $self)))))
   ($queen-cols $board-size $queen-cols)))
 
-;it works but I wasn't able to wait till it finishes calculations for (queens 4), though I've waited for ~12 hours.
-;!(queens 4)
-
-;Since (queens 4) is tough enough for current state of metta interpreter I've tried to run first two iterations to see
-;if everything is fine. Below is the second iteration and it gives right result:
-;(((1 1) (2 3)) ((1 1) (2 4)) ((1 2) (2 4)) ((1 3) (2 1)) ((1 4) (2 1)) ((1 4) (2 2)))
-;but it takes ~1.5 hours to compute so I'll leave it commented out.
-
-;!(assertEqual
-;    (filter
-;     (lambda1 $positions (safe? 2 $positions))
-;     (flatmap
-;      (lambda1 $rest-of-queens
-;        (map (lambda1 $new-row
-;               (adjoin-position $new-row 2 $rest-of-queens))
-;             (enumerate-interval 1 4)))
-;      (tree (((1 1)) ((1 2)) ((1 3)) ((1 4))))))
-;    (tree (((1 1) (2 3)) ((1 1) (2 4)) ((1 2) (2 4)) ((1 3) (2 1)) ((1 4) (2 1)) ((1 4) (2 2)))))
+!(assertEqual
+    (queens 4)
+    (tree (((1 2) (2 4) (3 1) (4 3)) ((1 3) (2 1) (3 4) (4 2)))))
 
 ; -----------------------End of Exercise 2.42---------------------------
 

--- a/SICP_book/chapter_2_3.metta
+++ b/SICP_book/chapter_2_3.metta
@@ -795,7 +795,7 @@
 
 (: lambda3 (-> Variable Variable Variable Atom (-> $a $b $c $t)))
 (= ((lambda3 $var1 $var2 $var3 $body) $val1 $val2 $val3)
-    (let (quote ($var1 $var2 $var3)) (quote ($val1 $val2 $val3)) $body))
+    (let (quote ($v1 $v2 $v3 $b)) (sealed ($var1 $var2 $var3) (quote ($var1 $var2 $var3 $body))) (let (quote ($v1 $v2 $v3)) (quote ($val1 $val2 $val3)) $b)) )
 
 (= (tree->list-2 $tree)
     (let $copy-to-list

--- a/SICP_book/chapter_2_4.metta
+++ b/SICP_book/chapter_2_4.metta
@@ -265,14 +265,15 @@
 
 (: lambda1 (-> Variable Atom (-> $a $t)))
 (= ((lambda1 $var $body) $val)
-    (let (quoted $var) (quoted $val) $body))
+    (let (quote ($v $b)) (sealed ($var) (quote ($var $body))) (let (quote $v) (quote $val) $b)) )
 
+(: lambda2 (-> Variable Variable Atom (-> $a $b $t)))
 (= ((lambda2 $var1 $var2 $body) $val1 $val2)
-    (let (quoted ($var1 $var2)) (quoted ($val1 $val2)) $body))
+    (let (quote ($v1 $v2 $b)) (sealed ($var1 $var2) (quote ($var1 $var2 $body))) (let (quote ($v1 $v2)) (quote ($val1 $val2)) $b)) )
 
 (: lambda3 (-> Variable Variable Variable Atom (-> $a $b $c $t)))
 (= ((lambda3 $var1 $var2 $var3 $body) $val1 $val2 $val3)
-    (let (quote ($var1 $var2 $var3)) (quote ($val1 $val2 $val3)) $body))
+    (let (quote ($v1 $v2 $v3 $b)) (sealed ($var1 $var2 $var3) (quote ($var1 $var2 $var3 $body))) (let (quote ($v1 $v2 $v3)) (quote ($val1 $val2 $val3)) $b)) )
 
 (= (car-list (Cons $x $xs))
     $x)


### PR DESCRIPTION
I've fixed almost everything (thanks to Vitaly) in the SICP chapters except chapter_2_2's scale-tree-m and square-tree-m. Currently I've placed some sort of stub-versions for them which is less preferable than original ones. But original versions not working for some unknown to me reason. Both are using case inside lambda's body and i thought that this is the problem but I've tried to write similar functions which uses case inside lambda's body and they worked just fine. So this could be something else. 